### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/lib/pdf-generator.ts
+++ b/lib/pdf-generator.ts
@@ -536,10 +536,12 @@ export class CharacterSheetPDFGenerator {
                 <span><strong>Race:</strong> ${escapeHtml(character.race)}${
             character.subrace ? ` (${escapeHtml(character.subrace)})` : ""
         }</span>
-                <span><strong>Background:</strong> ${
+                <span><strong>Background:</strong> ${escapeHtml(
                     character.background
-                }</span>
-                <span><strong>Alignment:</strong> ${character.alignment}</span>
+                )}</span>
+                <span><strong>Alignment:</strong> ${escapeHtml(
+                    character.alignment
+                )}</span>
             </div>
         </div>
         <div class="main-grid">


### PR DESCRIPTION
Potential fix for [https://github.com/PalmaAnd/DungeonsandDragonsToolBox/security/code-scanning/1](https://github.com/PalmaAnd/DungeonsandDragonsToolBox/security/code-scanning/1)

Best fix without changing functionality: ensure **all user-controlled fields are escaped before HTML interpolation** in `generateHTMLCharacterSheet` so `htmlContent` is safe even when written via `document.write`.

In `lib/pdf-generator.ts`, update unescaped interpolations in the HTML template:
- Escape `character.background` at the “Background” span.
- Escape `character.alignment` at the “Alignment” span.

No behavior change for normal users; only unsafe HTML injection is neutralized.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
